### PR TITLE
feat: add aliases for deploy, pod, and statefulset commands

### DIFF
--- a/internal/cmd/deployment.go
+++ b/internal/cmd/deployment.go
@@ -32,9 +32,10 @@ func NewDeployCmd(duplicator core.Duplicator, client core.Client) *cobra.Command
 		return duplicator, nil
 	}
 	deployCmd := &cobra.Command{
-		Use:   "deploy",
-		Short: "Duplicate a Deployment.",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "deploy",
+		Aliases: []string{"deployment", "deployments"},
+		Short:   "Duplicate a Deployment.",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			run := newDuplicateCmd(factory, client, schema.GroupVersionResource{
 				Group:    "apps",

--- a/internal/cmd/pod.go
+++ b/internal/cmd/pod.go
@@ -32,9 +32,10 @@ func NewPodCmd(duplicator core.Duplicator, client core.Client) *cobra.Command {
 		return duplicator, nil
 	}
 	podCmd := &cobra.Command{
-		Use:   "pod",
-		Short: "Duplicate a Pod.",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "pod",
+		Aliases: []string{"pods"},
+		Short:   "Duplicate a Pod.",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			run := newDuplicateCmd(factory, client, schema.GroupVersionResource{
 				Group:    "",

--- a/internal/cmd/statefulset.go
+++ b/internal/cmd/statefulset.go
@@ -32,9 +32,10 @@ func NewStatefulSetCmd(duplicator core.Duplicator, client core.Client) *cobra.Co
 		return duplicator, nil
 	}
 	deployCmd := &cobra.Command{
-		Use:   "statefulset",
-		Short: "Duplicate a StatefulSet.",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "statefulset",
+		Aliases: []string{"statefulsets"},
+		Short:   "Duplicate a StatefulSet.",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			run := newDuplicateCmd(factory, client, schema.GroupVersionResource{
 				Group:    "apps",


### PR DESCRIPTION
This allows users to invoke commands using either singular or plural forms, making the CLI more intuitive and user-friendly.

**Command alias improvements:**

* Added `deployment` and `deployments` as aliases for the `deploy` command in `internal/cmd/deployment.go`
* Added `pods` as an alias for the `pod` command in `internal/cmd/pod.go`
* Added `statefulsets` as an alias for the `statefulset` command in `internal/cmd/statefulset.go`